### PR TITLE
get logs of specific room

### DIFF
--- a/controller/datapoint_controller.go
+++ b/controller/datapoint_controller.go
@@ -37,13 +37,6 @@ type RoomLog struct {
 	Timestamp  time.Time     `json:"-" bson:"timestamp"`
 }
 
-type RoomLog struct {
-	ID         bson.ObjectId `json:"-" bson:"_id"`
-	RoomID     bson.ObjectId `json:"-" bson:"room"`
-	Occupation int           `json:"-" bson:"occupation"`
-	Timestamp  time.Time     `json:"-" bson:"timestamp"`
-}
-
 // NewDatapointController creates the controller
 func NewDatapointController(router *mux.Router, r *render.Render, db *mgo.Database) *DatapointController {
 	ctrl := &DatapointController{router, r, db.C("datapoint"), db, model.DatapointModel(db)}


### PR DESCRIPTION
Ik heb een methode gemaakt die via de volgende call de logs van een `Room` moet ophalen.
`GET` `{{ base_url }}/buildings/591ef303932c2b007938a88c/rooms/591ef303932c2b007938a88b/logs`

Mijn idee is om hier nog parameters aan te hangen zodat je de logs binnen een bepaalde tijd op zou kunnen halen. Bijvoorbeeld per half uur.

Ook heb ik in de DB een tabel aangemaakt `room_reservation` waarin ik hardcoded het volgende object heb gezet.

```
{
    "_id" : ObjectId("d5eb4f27f1f3e34d2fde74d7"),
    "room" : ObjectId("591ef303932c2b007938a88b"),
    "person_amount" : 30,
    "from" : ISODate("2017-05-21T13:00:00.951Z"),
    "till" : ISODate("2017-05-21T13:30:30.951Z")
}
```
 Op deze manier kunnen we op de front-end een vergelijking maken van de reservering met de daadwerkelijke occupation van een `Room`

**TODO:**
- [ ] Query parameters in GET call toevoegen.
